### PR TITLE
u-boot-ti-staging: Fix SPL boot loop

### DIFF
--- a/layers/meta-resin-beaglebone/recipes-bsp/u-boot/u-boot-ti-staging/0001-Integrate-with-Balena-environment-configuration.patch
+++ b/layers/meta-resin-beaglebone/recipes-bsp/u-boot/u-boot-ti-staging/0001-Integrate-with-Balena-environment-configuration.patch
@@ -1,54 +1,27 @@
-From 64ce5f8f1967e124a97ed6f751bb9f329cb3839a Mon Sep 17 00:00:00 2001
+From d0060275e5e1c6b6c40364f7ea134c37fa0b30b7 Mon Sep 17 00:00:00 2001
 From: Florin Sarbu <florin@balena.io>
-Date: Fri, 23 Nov 2018 09:40:37 +0100
+Date: Tue, 27 Nov 2018 13:46:12 +0100
 Subject: [PATCH] Integrate with Balena environment configuration
 
 Upstream-Status: Inappropriate [configuration]
 Signed-off-by: Florin Sarbu <florin@balena.io>
 ---
- configs/am335x_boneblack_defconfig | 5 +++--
- include/environment/ti/mmc.h       | 4 ++--
- 2 files changed, 5 insertions(+), 4 deletions(-)
+ configs/am335x_evm_defconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/configs/am335x_boneblack_defconfig b/configs/am335x_boneblack_defconfig
-index 50093cd..217d197 100644
---- a/configs/am335x_boneblack_defconfig
-+++ b/configs/am335x_boneblack_defconfig
-@@ -5,7 +5,7 @@ CONFIG_AM33XX=y
- # CONFIG_SPL_NAND_SUPPORT is not set
+diff --git a/configs/am335x_evm_defconfig b/configs/am335x_evm_defconfig
+index 568a4f5..829584e 100644
+--- a/configs/am335x_evm_defconfig
++++ b/configs/am335x_evm_defconfig
+@@ -6,7 +6,7 @@ CONFIG_DEFAULT_DEVICE_TREE="am335x-evm"
  CONFIG_DISTRO_DEFAULTS=y
- CONFIG_SYS_EXTRA_OPTIONS="EMMC_BOOT"
+ CONFIG_SPL_SYS_MALLOC_F_LEN=0x1000
+ CONFIG_SPL_LOAD_FIT=y
 -CONFIG_BOOTCOMMAND="if test ${boot_fit} -eq 1; then run update_to_fit; fi; run findfdt; run init_console; run envboot; run distro_bootcmd"
 +CONFIG_BOOTCOMMAND="if test ${boot_fit} -eq 1; then run update_to_fit; fi; run findfdt; run init_console; setenv resin_kernel_load_addr ${loadaddr}; run resin_set_kernel_root; setenv mmcdev ${resin_dev_index}; setenv bootpart ${resin_dev_index}:${resin_root_part}; run envboot; run mmcboot"
+ CONFIG_LOGLEVEL=3
  CONFIG_SYS_CONSOLE_INFO_QUIET=y
  CONFIG_VERSION_VARIABLE=y
- CONFIG_ARCH_MISC_INIT=y
-@@ -20,7 +20,8 @@ CONFIG_FASTBOOT=y
- CONFIG_CMD_SPL=y
- # CONFIG_CMD_FLASH is not set
- # CONFIG_CMD_SETEXPR is not set
--CONFIG_ENV_IS_IN_MMC=y
-+# CONFIG_ENV_IS_IN_MMC is not set
-+CONFIG_ENV_IS_NOWHERE=y
- CONFIG_DFU_TFTP=y
- CONFIG_DFU_MMC=y
- CONFIG_DFU_RAM=y
-diff --git a/include/environment/ti/mmc.h b/include/environment/ti/mmc.h
-index 4305ebd..8cd6305 100644
---- a/include/environment/ti/mmc.h
-+++ b/include/environment/ti/mmc.h
-@@ -13,9 +13,9 @@
- 	"mmcdev=0\0" \
- 	"mmcrootfstype=ext4 rootwait\0" \
- 	"finduuid=part uuid mmc ${bootpart} uuid\0" \
--	"args_mmc=run finduuid;setenv bootargs console=${console} " \
-+	"args_mmc=setenv bootargs console=${console} " \
- 		"${optargs} " \
--		"root=PARTUUID=${uuid} rw " \
-+		"${resin_kernel_root} " \
- 		"rootfstype=${mmcrootfstype}\0" \
- 	"loadbootscript=load mmc ${mmcdev} ${loadaddr} boot.scr\0" \
- 	"bootscript=echo Running bootscript from mmc${mmcdev} ...; " \
 -- 
 2.7.4
 

--- a/layers/meta-resin-beaglebone/recipes-bsp/u-boot/u-boot-ti-staging/0002-am335x_evm_defconfig-Reduce-SPL-.rodata-size.patch
+++ b/layers/meta-resin-beaglebone/recipes-bsp/u-boot/u-boot-ti-staging/0002-am335x_evm_defconfig-Reduce-SPL-.rodata-size.patch
@@ -1,0 +1,75 @@
+From 56dce6462e60e2aa5b87c97c5a2c43a4d834e251 Mon Sep 17 00:00:00 2001
+From: "Kemal R. Shakir" <kemal@ti.com>
+Date: Wed, 3 Oct 2018 15:56:37 +0300
+Subject: [PATCH 1/1] am335x_evm_defconfig: Reduce SPL `.rodata' size
+
+Upstream-Status: Pending
+Signed-off-by: Florin Sarbu <florin@balena.io>
+---
+ configs/am335x_evm_defconfig | 54 ++++++++++++++++++++++++++++++++++++
+ 1 file changed, 54 insertions(+)
+
+diff --git a/configs/am335x_evm_defconfig b/configs/am335x_evm_defconfig
+index 4908099431..568a4f535e 100644
+--- a/configs/am335x_evm_defconfig
++++ b/configs/am335x_evm_defconfig
+@@ -63,3 +63,57 @@ CONFIG_DYNAMIC_CRC_TABLE=y
+ CONFIG_SPL_TINY_MEMSET=y
+ CONFIG_RSA=y
+ CONFIG_LZO=y
++
++#
++# SPL / TPL
++#
++CONFIG_SUPPORT_SPL=y
++CONFIG_SPL=y
++CONFIG_SPL_BOARD_INIT=y
++# CONFIG_SPL_BOOTROM_SUPPORT is not set
++CONFIG_SPL_RAW_IMAGE_SUPPORT=y
++CONFIG_SPL_LEGACY_IMAGE_SUPPORT=y
++CONFIG_SPL_SYS_MALLOC_SIMPLE=y
++# CONFIG_TPL_SYS_MALLOC_SIMPLE is not set
++CONFIG_SPL_STACK_R=y
++CONFIG_SPL_STACK_R_MALLOC_SIMPLE_LEN=0x100000
++CONFIG_SPL_SEPARATE_BSS=y
++# CONFIG_SPL_DISPLAY_PRINT is not set
++CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_USE_SECTOR=y
++CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_SECTOR=0x300
++# CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_USE_PARTITION is not set
++# CONFIG_SPL_CRC32_SUPPORT is not set
++# CONFIG_SPL_MD5_SUPPORT is not set
++# CONFIG_SPL_SHA1_SUPPORT is not set
++# CONFIG_SPL_SHA256_SUPPORT is not set
++# CONFIG_SPL_FIT_IMAGE_TINY is not set
++# CONFIG_SPL_CPU_SUPPORT is not set
++# CONFIG_SPL_CRYPTO_SUPPORT is not set
++# CONFIG_SPL_HASH_SUPPORT is not set
++# CONFIG_SPL_DMA_SUPPORT is not set
++# CONFIG_SPL_ENV_SUPPORT is not set
++CONFIG_SPL_EXT_SUPPORT=y
++# CONFIG_SPL_FPGA_SUPPORT is not set
++CONFIG_SPL_I2C_SUPPORT=y
++# CONFIG_SPL_MMC_WRITE is not set
++# CONFIG_SPL_MPC8XXX_INIT_DDR_SUPPORT is not set
++CONFIG_SPL_MTD_SUPPORT=y
++CONFIG_SPL_MUSB_NEW_SUPPORT=y
++CONFIG_SPL_NET_SUPPORT=y
++CONFIG_SPL_NET_VCI_STRING="AM335x U-Boot SPL"
++# CONFIG_SPL_NO_CPU_SUPPORT is not set
++# CONFIG_SPL_NOR_SUPPORT is not set
++# CONFIG_SPL_XIP_SUPPORT is not set
++# CONFIG_SPL_ONENAND_SUPPORT is not set
++CONFIG_SPL_OS_BOOT=y
++# CONFIG_SPL_PCI_SUPPORT is not set
++# CONFIG_SPL_PCH_SUPPORT is not set
++# CONFIG_SPL_POST_MEM_SUPPORT is not set
++CONFIG_SPL_POWER_SUPPORT=y
++# CONFIG_SPL_RAM_SUPPORT is not set
++# CONFIG_SPL_RTC_SUPPORT is not set
++# CONFIG_SPL_SATA_SUPPORT is not set
++# CONFIG_SPL_THERMAL is not set
++# CONFIG_SPL_USB_HOST_SUPPORT is not set
++# CONFIG_SPL_USB_GADGET_SUPPORT is not set
++# CONFIG_SPL_YMODEM_SUPPORT is not set
+--
+2.17.1

--- a/layers/meta-resin-beaglebone/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
+++ b/layers/meta-resin-beaglebone/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
@@ -1,9 +1,12 @@
 UBOOT_KCONFIG_SUPPORT = "1"
 inherit resin-u-boot
 
+UBOOT_MACHINE = "am335x_evm_config"
+
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI_append = " \
     file://0001-Integrate-with-Balena-environment-configuration.patch \
+    file://0002-am335x_evm_defconfig-Reduce-SPL-.rodata-size.patch \
     file://0005-Autoboot-keyboard-beaglebone-fixes.patch \
     file://0001-Add-support-for-BeagleBoard.org-PocketBeagle.patch \
     file://uEnv.txt_internal \


### PR DESCRIPTION
The BSP layer at the rocko branch has an issue with the boot
stuck in a loop. See details here:
https://lists.yoctoproject.org/pipermail/meta-ti/2018-October
/011363.html

Changelog-entry: Fix boot loop hang when switched to meta-ti rocko
Signed-off-by: Florin Sarbu <florin@balena.io>